### PR TITLE
fixes hstack ignoring its first argument

### DIFF
--- a/src/jutsu/matrix/core.clj
+++ b/src/jutsu/matrix/core.clj
@@ -258,7 +258,7 @@
 
 (defn hstack
   "Concatenates two matrices horizontally."
-  ([arr & args] (Nd4j/hstack (into-array args))))
+  ([& args] (Nd4j/hstack (into-array args))))
 
 (defn ones-like
   "Ones like."

--- a/test/jutsu/matrix/test.clj
+++ b/test/jutsu/matrix/test.clj
@@ -47,6 +47,12 @@
   (is (jm/equals? (jm/matrix [[1 2 3 4] [4 3 2 1]])
         (jm/vstack (jm/matrix [1 2 3 4]) (jm/matrix [4 3 2 1])))))
 
+(deftest hstack
+  (is (jm/equals? (jm/matrix [[1 2 3 4 1 5 3 5] [4 3 2 1 6 5 4 3]])
+        (jm/hstack (jm/matrix [[1 2 3 4] [4 3 2 1]]) (jm/matrix [1 5 3 5] [6 5 4 3]))))
+  (is (jm/equals? (jm/matrix [1 2 3 4 4 3 2 1])
+        (jm/hstack (jm/matrix [1 2 3 4]) (jm/matrix [4 3 2 1])))))
+
 (deftest shape
   (is (= [2 4] (jm/shape test-m1))))
 


### PR DESCRIPTION
first off; great job on jutsu.matrix! i appreciate the work you're putting in 👍 . while using the library i came across a little bug: `hstack` ignoring its first argument. this pull request fixes the argument list and adds a test for the method