### PR TITLE
Quick hacks for upgrading to new release of DL4J funtimes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 /checkouts/
 .nightlight.edn
 test-m1.txt
+/.idea
+*.iml

--- a/build.boot
+++ b/build.boot
@@ -3,8 +3,8 @@
   :dependencies '[[org.clojure/clojure "1.8.0"]
                   [nightlight "1.7.0" :scope "test"]
                   [adzerk/boot-test "1.2.0" :scope "test"]
-                  [org.nd4j/nd4j-native-platform "0.8.0" :scope "test"]
-                  [org.nd4j/nd4j-api "0.8.0"]
+                  [org.nd4j/nd4j-native-platform "1.0.0-alpha" :scope "test"]
+                  [org.nd4j/nd4j-api "1.0.0-alpha"]
                   [boot-codox "0.10.3" :scope "test"]]
   :repositories (conj (get-env :repositories)
                       ["clojars" {:url "https://clojars.org/repo"
@@ -14,7 +14,7 @@
 (task-options!
   jar {:main 'jutsu.matrix.core
        :manifest {"Description" "jutsu.matrix is a linear algebra library meant for the jutsu data science framework"}}
-  pom {:version "0.0.14"
+  pom {:version "0.0.15"
        :project 'hswick/jutsu.matrix
        :description "jutsu.matrix is a linear algebra library meant for the jutsu data science framework"
        :url "https://github.com/hswick/jutsu.matrix"}
@@ -24,6 +24,7 @@
   (comp
     (pom)
     (jar)
+    (install)
     (push)))
 
 ;;So nightlight can still open even if there is an error in the core file
@@ -55,7 +56,7 @@
   (comp
     (codox :name "jutsu.matrix"
       :description "Clojure library for linear algebra operations, wraps ND4J."
-      :version "0.0.14"
+      :version "0.0.15"
       :source-paths #{"src/jutsu/matrix/"}
       :output-path "docs")
     (target)))

--- a/src/jutsu/matrix/core.clj
+++ b/src/jutsu/matrix/core.clj
@@ -66,9 +66,10 @@
   "This method returns BasicNDArrayCompressor instance, suitable for NDArray compression/decompression at runtime."
   [] (Nd4j/getCompressor))
 
-(defn get-fft
-  "Returns the fft instance."
-  [] (Nd4j/getFFt))
+; TODO figure out why this was removed
+;(defn get-fft
+;  "Returns the fft instance."
+;  [] (Nd4j/getFFt))
 
 (defn fallback-mode-enabled?
   "Checks if fallback mode was enabled."

--- a/test/jutsu/matrix/test.clj
+++ b/test/jutsu/matrix/test.clj
@@ -35,7 +35,7 @@
     (is (jm/equals? matrix-2s zeros-2s))))
 
 (deftest to-string
-  (is (= "[1.00, 3.00, 4.00]" (jm/to-string (jm/matrix [1 3 4])))))
+  (is (= "[[    1.0000,    3.0000,    4.0000]]" (jm/to-string (jm/matrix [1 3 4])))))
 
 (deftest concatenation
   (is (jm/equals? (jm/matrix [[1 2 3 4] [4 3 2 1]])


### PR DESCRIPTION
I'm working on upgrading justsu.ai to use the new 1.0.0-alpha release of DL4J and the `getFFt` method is missing in the new release. I don't know why or if we still need that function, but I've commented it out and pushed this for now so that I can continue my work over in jutsu.ai. I ran the boot tests. One of them is failing, but I'm not sure if it's related to my changes or not.